### PR TITLE
change to fix bug https://github.com/devcenter-square/states-cities/issues/1

### DIFF
--- a/app/mod_endpoints/models.py
+++ b/app/mod_endpoints/models.py
@@ -29,7 +29,7 @@ class State(Object):
             state = State.Query.get(state_code=code)
             return state.as_dict()
         elif len(state_name_or_code) > 2:
-            state_name = state_name_or_code.capitalize()
+            state_name = state_name_or_code.title()
             state = State.Query.get(name=state_name)
             return state.as_dict()
 


### PR DESCRIPTION
This change makes it possible to search using the name of states with spaces. Eg Cross River.

``` py
python
>>> 'Cross River'.capitalize()
'Cross river'
>>> 'Cross River'.title()
'Cross River'
```
