### PR TITLE
Modernize codebase: Python 3, secure keys, fix docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PARSE_APPLICATION_ID=your_parse_application_id
+PARSE_REST_API_KEY=your_parse_rest_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Environment variables
+.env
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# States & Cities API
+
+A public REST API providing Nigerian states, cities, and local government areas (LGAs). Built with Python 2 / Flask, backed by Parse as the data store.
+
+## Project Structure
+
+```
+app/
+  __init__.py              # Flask app setup, Parse connection, error handler registration
+  mod_endpoints/
+    __init__.py
+    controllers.py         # Blueprint with API route handlers (url prefix: /api/v1)
+    models.py              # Parse ORM models (State, LGA) with query methods
+    exceptions.py          # InvalidAPIUsage custom exception class
+run.py                     # Local dev server (0.0.0.0:8080)
+passenger_wsgi.py          # WSGI entry point for production (Passenger)
+requirements.txt           # Pinned Python 2 dependencies
+```
+
+## API Endpoints
+
+All routes are under `/api/v1`:
+
+- `GET /states` — list all states
+- `GET /state/<name_or_code>` — single state by name or 2-letter code
+- `GET /state/<name_or_code>/lgas` — LGAs for a state
+- `GET /state/<name_or_code>/cities` — cities for a state (LGAs with `city=True`)
+
+## Key Details
+
+- **Python 2**: Uses Python 2 syntax (`print` statement, `except X, e:` form, `urllib.unquote`).
+- **Parse backend**: Data is stored in Parse (connected via `parse_rest`). Models extend `parse_rest.datatypes.Object`. Parse keys are in `app/__init__.py`.
+- **State lookup**: 2-character input is treated as a state code (uppercased); longer input is treated as a state name (title-cased).
+- **No tests**: There is no test suite.
+
+## Running Locally
+
+```bash
+pip install -r requirements.txt
+python run.py
+# Server starts at http://localhost:8080
+```

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Field | Description
 ------|------------
 name | The name of the state.
 capital | The capital of the state.
-latitude | It's longitude.
-longitude | It's latitude.
+latitude | The latitude of the state.
+longitude | The longitude of the state.
 minLat | The minimum latitude of it's boundary.
 minLong | The minimum longitude of it's boundary.
 maxLat | The maximum latitude of it's boundary.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,4 @@
+import os
 from flask import Flask, jsonify
 from parse_rest.connection import register
 
@@ -10,7 +11,7 @@ from app.mod_endpoints.exceptions import InvalidAPIUsage
 app.register_blueprint(endpoints_module)
 
 #connect to Parse
-register('azP8OG6mI6hw4OQC4hl5La5B2me8b2yk67qTTJVl', 'PWT4hbPVtZ59MU73OfIxjhpCVIkqXYOOb4LY8ars')
+register(os.environ['PARSE_APPLICATION_ID'], os.environ['PARSE_REST_API_KEY'])
 
 @app.errorhandler(InvalidAPIUsage)
 def handle_invalid_usage(error):

--- a/app/mod_endpoints/controllers.py
+++ b/app/mod_endpoints/controllers.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, Response
 from json import dumps
-import urllib
+from urllib.parse import unquote
 # Import module models
 from app.mod_endpoints.models import State
 from app.mod_endpoints.models import LGA
@@ -17,15 +17,15 @@ def get_states():
 
 @mod_endpoints.route('/state/<state_name_or_code>', methods=['GET'])
 def get_state(state_name_or_code):
-    state = State.get_one_state(urllib.unquote(state_name_or_code))
+    state = State.get_one_state(unquote(state_name_or_code))
     return Response(dumps(state), mimetype='application/json')
 
 @mod_endpoints.route('/state/<state_name_or_code>/lgas', methods=['GET'])
 def get_lgas(state_name_or_code):
-    lgas = LGA.get_all_lgas(urllib.unquote(state_name_or_code))
+    lgas = LGA.get_all_lgas(unquote(state_name_or_code))
     return Response(dumps(lgas), mimetype='application/json')
 
 @mod_endpoints.route('/state/<state_name_or_code>/cities', methods=['GET'])
 def get_cities(state_name_or_code):
-    cities = LGA.get_all_cities(urllib.unquote(state_name_or_code))
+    cities = LGA.get_all_cities(unquote(state_name_or_code))
     return Response(dumps(cities), mimetype='application/json')

--- a/app/mod_endpoints/models.py
+++ b/app/mod_endpoints/models.py
@@ -24,7 +24,7 @@ class State(Object):
             elif len(state_name_or_code) > 2:
                 state = State.Query.get(name=state_name_or_code.title())
             return state
-        except QueryResourceDoesNotExist, e:
+        except QueryResourceDoesNotExist as e:
             raise InvalidAPIUsage("State with state name or code '{}' does not exist".format(state_name_or_code), status_code=404)
 
     @staticmethod
@@ -46,16 +46,6 @@ class LGA(Object):
     def find_state_cities(cls,state_name_or_code):
         _state_ = State.find_by_name_or_code(state_name_or_code)
         return [ lga.as_dict() for lga in LGA.Query.filter( state=_state_, city=True ) ]
-
-    @staticmethod
-    def get_all_lgas_with_state_name(state_name):
-        result_set = []
-        state_result = State.Query.get(name=state_name)
-        print state_result.objectId
-        lgas = LGA.Query.filter(state=state_result)
-        for lga in lgas:
-            result_set.append(lga.as_dict())
-        return result_set
 
     @staticmethod
     def get_all_lgas(state_name_or_code):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-Flask==0.10.1
-itsdangerous==0.24
-Jinja2==2.8
-MarkupSafe==0.23
+Flask==2.3.3
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.3
 parse-rest==0.2.20141004
-six==1.10.0
-Werkzeug==0.10.4
-wheel==0.24.0
+Werkzeug==2.3.7
+wheel==0.41.2


### PR DESCRIPTION
## Summary
- Upgrade Python 2 syntax to Python 3 (`except as`, `urllib.parse`, `print()`)
- Move hardcoded Parse API keys to environment variables with `.env.example`
- Fix swapped latitude/longitude descriptions in README
- Remove unused `get_all_lgas_with_state_name` method and debug `print` statement
- Update Flask and dependencies to Python 3-compatible versions; remove `six`
- Add `CLAUDE.md` project guide

## Test plan
- [ ] Set `PARSE_APPLICATION_ID` and `PARSE_REST_API_KEY` env vars and run `python run.py`
- [ ] Verify all 4 API endpoints return correct JSON responses
- [ ] Confirm no hardcoded keys remain in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)