### PR TITLE
Add CLAUDE.md project guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # States & Cities API
 
-A public REST API providing Nigerian states, cities, and local government areas (LGAs). Built with Python 2 / Flask, backed by Parse as the data store.
+A public REST API providing Nigerian states, cities, and local government areas (LGAs). Built with Python 3 / Flask, backed by Parse as the data store.
 
 ## Project Structure
 
@@ -14,7 +14,8 @@ app/
     exceptions.py          # InvalidAPIUsage custom exception class
 run.py                     # Local dev server (0.0.0.0:8080)
 passenger_wsgi.py          # WSGI entry point for production (Passenger)
-requirements.txt           # Pinned Python 2 dependencies
+requirements.txt           # Pinned Python 3 dependencies
+.env.example               # Required environment variables template
 ```
 
 ## API Endpoints
@@ -28,15 +29,18 @@ All routes are under `/api/v1`:
 
 ## Key Details
 
-- **Python 2**: Uses Python 2 syntax (`print` statement, `except X, e:` form, `urllib.unquote`).
-- **Parse backend**: Data is stored in Parse (connected via `parse_rest`). Models extend `parse_rest.datatypes.Object`. Parse keys are in `app/__init__.py`.
+- **Parse backend**: Data is stored in Parse (connected via `parse_rest`). Models extend `parse_rest.datatypes.Object`. Parse keys are read from environment variables (`PARSE_APPLICATION_ID`, `PARSE_REST_API_KEY`).
 - **State lookup**: 2-character input is treated as a state code (uppercased); longer input is treated as a state name (title-cased).
 - **No tests**: There is no test suite.
+- **parse-rest dependency**: The `parse-rest` package is largely unmaintained. It has partial Python 3 support but may need replacement in the future.
 
 ## Running Locally
 
 ```bash
+cp .env.example .env
+# Edit .env with your Parse credentials
 pip install -r requirements.txt
+export $(cat .env | xargs)
 python run.py
 # Server starts at http://localhost:8080
 ```


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` documenting project structure, API endpoints, key details, and local setup instructions

## Test plan
- [ ] Verify CLAUDE.md content is accurate against the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)