### PR TITLE
Update README with live Railway links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,13 @@ About.
 
 It just a simple API that lets you get a list of states, cities and local government areas in Nigeria. In JSON duh. It's made for the developer who wants to make a simple drop down list of Nigerian locations for any app in any language. (It's also not limited to that developer's use case).
 
-It's built in Python with Flask using Parse as a data store.
-More on getting the information directly from Parse below.
+It's built in Python with Flask using a local JSON dataset.
 
 
 URI and Versioning.
 -------------
 
-We hope to improve this API over time, and these changes won't always be backward compatible, so we're going to version the API. This first iteration will be live at states-and-cities.com/api/v1/ and is structured as described below.
+We hope to improve this API over time, and these changes won't always be backward compatible, so we're going to version the API. This first iteration will be live at overflowing-strength-production.up.railway.app/api/v1/ and is structured as described below.
 
 
 ----------
@@ -27,7 +26,7 @@ We hope to improve this API over time, and these changes won't always be backwar
 
 ## States
 
-To get a list of all states in Nigeria, call the endpoint at http://states-and-cities.com/api/v1/states.
+To get a list of all states in Nigeria, call the endpoint at https://overflowing-strength-production.up.railway.app/api/v1/states.
 
 All states have the following properties:
 
@@ -37,25 +36,17 @@ name | The name of the state.
 capital | The capital of the state.
 latitude | The latitude of the state.
 longitude | The longitude of the state.
-minLat | The minimum latitude of it's boundary.
-minLong | The minimum longitude of it's boundary.
-maxLat | The maximum latitude of it's boundary.
-maxLong | The maximum longitude of it's boundary.
 
 
 States are identified using their names or a code, which are unique.
-For example, a state: http://states-and-cities.com/api/v1/state/lagos
+For example, a state: https://overflowing-strength-production.up.railway.app/api/v1/state/lagos
 
 ```json
 {
   "name": "Lagos",
-  "maxLat": 6.7027984,
-  "minLong": 3.0982732,
-  "longitude": 3.3792057,
-  "maxLong": 3.696727799999999,
-  "minLat": 6.3936419,
-  "latitude": 6.5243793,
-  "capital": "Ikeja"
+  "capital": "Ikeja",
+  "latitude": 6.5269033,
+  "longitude": 3.5774005
 }
 ```
 
@@ -63,14 +54,14 @@ For example, a state: http://states-and-cities.com/api/v1/state/lagos
 
 ## Local Government Areas (LGAs)
 
-LGAs belong to a state and they are identified by their names. 
+LGAs belong to a state and they are identified by their names.
 All LGAs have the following properties:
 
 Field | Description
 ------|------------
 name | The name of the LGA.
 
-For example, LGAs in Kaduna: http://states-and-cities.com/api/v1/state/kaduna/lgas
+For example, LGAs in Kaduna: https://overflowing-strength-production.up.railway.app/api/v1/state/kaduna/lgas
 
 ```json
 [
@@ -157,18 +148,7 @@ Field | Description
 ------|------------
 name | The name of the city.
 
-For example, Cities in Ogun:http://states-and-cities.com/api/v1/state/ogun/cities
-
-```json
-[
-  {
-    "name": "Ijebu Ode"
-  },
-  {
-    "name": "Shagamu"
-  }
-]
-```
+> **Note:** City data is not currently available. The `/cities` endpoint returns an empty list. This data was previously stored in Parse.com, which shut down in 2017.
 
 
 List of endpoints
@@ -181,18 +161,6 @@ This is just a summary of all four endpoints you can call.
 - `GET /state/<state_name_or_code>/cities` returns a list of cities in a state. You can either pass in the state name i.e `lagos` or the state code i.e `LA`.
 
 
-Using Parse SDKs
---------------------
-
-Since this is a Parse backed application, you can skip the API, if say, you're already using Parse in your application or you'd just rather use Parse's SDK than the API.
-
-You can find the parse keys in `/app/__init__.py` and can use them to only read data. Attempting to write anything to our db is a declaration of eternal war with the Knights of Devcenter Square.
-
-There are two classes of concern if you're using any of the Parse SDKs.
-- `State` there are 36 of them...actually, no 37 of them. LOL. Do with them you what you may.
-- `LGA` These are the local government areas. A city is just a local government area with `city = true`.
-
-
 Contributing
 --------------------
 
@@ -201,4 +169,3 @@ We welcome any and all contributions, code cleanups and feature requests.
 1. Check for open issues or open a fresh issue to start a discussion around a feature idea or a bug.
 2. Fork the repository on GitHub to start making your changes to the **master** branch (or branch off of it).
 3. Send a pull request and bug the maintainer until it gets merged and published. :).
-


### PR DESCRIPTION
## Summary
- Replace all dead `states-and-cities.com` URLs with live Railway deployment: `https://overflowing-strength-production.up.railway.app`
- Update "About" section: Flask with local JSON dataset (no longer Parse)
- Remove `minLat`, `minLong`, `maxLat`, `maxLong` from state properties table and example response
- Update Lagos example JSON to match current API output
- Add note that `/cities` endpoint currently returns empty (data lost with Parse.com shutdown in 2017)
- Remove obsolete "Using Parse SDKs" section

## Test plan
- [ ] Verify all README links return valid JSON responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)